### PR TITLE
Fix a bug

### DIFF
--- a/lectio/_modul.py
+++ b/lectio/_modul.py
@@ -7,7 +7,7 @@ def modul(self, absid):
 
     modulDetaljer = {
         "aktivitet": None,
-        "note": None,
+        "note": "",
         "lektier": "",
         "øvrigtIndhold": ""
     }


### PR DESCRIPTION
Note should be an empty string, because when a module doesn't have a note, it will be `None` instead of `""`. This makes Better Lectio break if the module doesn't have a note. Instead of fixing it on Better Lectio's side, it should just be standardized like the `lektier` entry being `""` too.